### PR TITLE
-bugfix: export folder did not work as intended

### DIFF
--- a/AAPakEditor/AAPakEditor.csproj
+++ b/AAPakEditor/AAPakEditor.csproj
@@ -24,8 +24,8 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>1</ApplicationRevision>
-    <ApplicationVersion>0.3.0.%2a</ApplicationVersion>
+    <ApplicationRevision>2</ApplicationRevision>
+    <ApplicationVersion>0.3.1.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/AAPakEditor/ExportAllDlg.cs
+++ b/AAPakEditor/ExportAllDlg.cs
@@ -71,8 +71,11 @@ namespace AAPakEditor
                 if (bgwExport.CancellationPending)
                     return;
 
-                if ((masterRoot != "") && (pfi.name.Length > masterRoot.Length) && (pfi.name.Substring(0, masterRoot.Length) != masterRoot))
-                    continue;
+                if (masterRoot != "")
+                {
+                    if ((pfi.name.Length <= masterRoot.Length) || (pfi.name.Substring(0, masterRoot.Length) != masterRoot))
+                        continue;
+                }
 
                 TotalSize += pfi.size;
                 TotalFileCountToExport++;
@@ -85,8 +88,11 @@ namespace AAPakEditor
                 if (bgwExport.CancellationPending)
                     break;
 
-                if ((masterRoot != "") && (pfi.name.Length > masterRoot.Length) && (pfi.name.Substring(0, masterRoot.Length) != masterRoot))
-                    continue;
+                if (masterRoot != "")
+                {
+                    if ((pfi.name.Length <= masterRoot.Length) || (pfi.name.Substring(0, masterRoot.Length) != masterRoot))
+                        continue;
+                }
 
                 var destName = TargetDir + Path.DirectorySeparatorChar;
                 var exportedFileName = pfi.name.Substring(masterRoot.Length);

--- a/AAPakEditor/MainForm.cs
+++ b/AAPakEditor/MainForm.cs
@@ -17,7 +17,7 @@ namespace AAPakEditor
     public partial class MainForm : Form
     {
         public AAPak pak;
-        private string versionString = "0.3";
+        private string versionString = "0.3.1";
         private string urlGitHub = "https://github.com/ZeromusXYZ/AAEmu-Packer";
         private string baseTitle = "";
         private string currentFileViewFolder = "";


### PR DESCRIPTION
Export folder was not working as intended. It could possibly "crash" the export. when exporting a non-root folder or T1 folder.